### PR TITLE
Implement backtest option

### DIFF
--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -1,3 +1,3 @@
 """Utilities for scanning NSE F&O stocks for bullish setups."""
 
-__all__ = ["fetch_fno_list", "filter_by_dma", "intraday_scan"]
+__all__ = ["fetch_fno_list", "filter_by_dma", "intraday_scan", "backtest_strategy"]

--- a/nse_fno_scanner/backtester.py
+++ b/nse_fno_scanner/backtester.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import yfinance as yf
+from typing import Tuple
+
+from .intraday_scanner import compute_emas, pattern_confirmed
+
+
+def backtest_strategy(symbol: str, period: str = "6mo") -> Tuple[int, float, float]:
+    """Backtest the intraday strategy on daily data for a symbol.
+
+    Parameters
+    ----------
+    symbol : str
+        Equity ticker symbol without NSE suffix.
+    period : str, optional
+        Period to download historical data for (default "6mo").
+
+    Returns
+    -------
+    Tuple[int, float, float]
+        Number of trades, win rate percentage, average return percentage.
+    """
+    try:
+        df = yf.download(f"{symbol}.NS", period=period, interval="1d", progress=False)
+    except Exception:
+        return 0, 0.0, 0.0
+    if df.empty or len(df) < 50:
+        return 0, 0.0, 0.0
+
+    df = compute_emas(df)
+    trades = []
+    closes = df["Close"].reset_index(drop=True)
+    for i in range(4, len(df) - 1):
+        window = df.iloc[i - 4 : i + 1]
+        if (
+            window["EMA20"].iloc[-1] >= window["EMA50"].iloc[-1]
+            and pattern_confirmed(window)
+        ):
+            entry = closes.iloc[i]
+            exit_price = closes.iloc[i + 1]
+            trades.append((exit_price - entry) / entry)
+
+    if not trades:
+        return 0, 0.0, 0.0
+
+    win_rate = sum(1 for r in trades if r > 0) / len(trades) * 100
+    avg_return = sum(trades) / len(trades) * 100
+    return len(trades), win_rate, avg_return

--- a/run_scan.py
+++ b/run_scan.py
@@ -7,12 +7,13 @@ from tqdm import tqdm
 from nse_fno_scanner.fetch_fno_list import fetch_fno_list
 from nse_fno_scanner.dma_filter import filter_by_dma
 from nse_fno_scanner.intraday_scanner import intraday_scan
+from nse_fno_scanner.backtester import backtest_strategy
 
 
 DEFAULT_LOG = Path("scan_results.txt")
 
 
-def run(output: Path = DEFAULT_LOG) -> None:
+def run(output: Path = DEFAULT_LOG, backtest: bool = False) -> None:
     symbols = fetch_fno_list()
     symbols = filter_by_dma(symbols)
     results = intraday_scan(symbols)
@@ -21,6 +22,12 @@ def run(output: Path = DEFAULT_LOG) -> None:
     print(f"Shortlisted stocks ({len(results)}):")
     for sym in results:
         print(sym)
+
+    if backtest:
+        print("\nBacktest results:")
+        for sym in results:
+            trades, win_rate, avg_ret = backtest_strategy(sym)
+            print(f"{sym}: trades={trades}, win_rate={win_rate:.1f}%, avg_return={avg_ret:.2f}%")
 
 
 def main() -> None:
@@ -31,8 +38,13 @@ def main() -> None:
         default=DEFAULT_LOG,
         help="File to write scan results",
     )
+    parser.add_argument(
+        "--backtest",
+        action="store_true",
+        help="Run simple backtest for shortlisted stocks",
+    )
     args = parser.parse_args()
-    run(args.output)
+    run(args.output, args.backtest)
 
 
 if __name__ == "__main__":

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import pandas as pd
+import yfinance as yf
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nse_fno_scanner.backtester import backtest_strategy
+
+
+def test_backtest_strategy(monkeypatch):
+    data = pd.DataFrame({"Close": list(range(1, 120))})
+
+    def fake_download(*args, **kwargs):
+        return data
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    trades, win_rate, avg_ret = backtest_strategy("TEST")
+    assert trades >= 0
+    assert 0.0 <= win_rate <= 100.0

--- a/tests/test_dma_filter.py
+++ b/tests/test_dma_filter.py
@@ -1,4 +1,9 @@
+import os
+import sys
 import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from nse_fno_scanner.dma_filter import compute_dmas
 
 

--- a/tests/test_intraday_scanner.py
+++ b/tests/test_intraday_scanner.py
@@ -1,4 +1,9 @@
+import os
+import sys
 import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from nse_fno_scanner.intraday_scanner import compute_emas, pattern_confirmed
 
 


### PR DESCRIPTION
## Summary
- add a `backtest_strategy` helper for quick EMA crossover backtests
- expose it via `nse_fno_scanner` package
- support `--backtest` flag in `run_scan.py`
- update tests and add new unit test for backtester

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655ab0da388320931464f2224add3b