### PR TITLE
Expose package exports

### DIFF
--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -1,3 +1,13 @@
 """Utilities for scanning NSE F&O stocks for bullish setups."""
 
-__all__ = ["fetch_fno_list", "filter_by_dma", "intraday_scan", "backtest_strategy"]
+from .fetch_fno_list import fetch_fno_list
+from .dma_filter import filter_by_dma
+from .intraday_scanner import intraday_scan
+from .backtester import backtest_strategy
+
+__all__ = [
+    "fetch_fno_list",
+    "filter_by_dma",
+    "intraday_scan",
+    "backtest_strategy",
+]

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -5,7 +5,7 @@ import yfinance as yf
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from nse_fno_scanner.backtester import backtest_strategy
+from nse_fno_scanner import backtest_strategy
 
 
 def test_backtest_strategy(monkeypatch):

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,13 @@
+from nse_fno_scanner import (
+    fetch_fno_list,
+    filter_by_dma,
+    intraday_scan,
+    backtest_strategy,
+)
+
+
+def test_root_exports_callable():
+    assert callable(fetch_fno_list)
+    assert callable(filter_by_dma)
+    assert callable(intraday_scan)
+    assert callable(backtest_strategy)


### PR DESCRIPTION
## Summary
- import main functions in `__init__` so they're exposed at the package root
- update tests to import from the package root
- add a simple export test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68655e1f15688320b28642f87ca3a170