### PR TITLE
Add market prediction and Telegram notifications

### DIFF
--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -4,10 +4,18 @@ from .fetch_fno_list import fetch_fno_list
 from .dma_filter import filter_by_dma
 from .intraday_scanner import intraday_scan
 from .backtester import backtest_strategy
+from .market_predictor import (
+    predict_index_movement,
+    compare_with_indices,
+    send_telegram_message,
+)
 
 __all__ = [
     "fetch_fno_list",
     "filter_by_dma",
     "intraday_scan",
     "backtest_strategy",
+    "predict_index_movement",
+    "compare_with_indices",
+    "send_telegram_message",
 ]

--- a/nse_fno_scanner/market_predictor.py
+++ b/nse_fno_scanner/market_predictor.py
@@ -1,0 +1,45 @@
+import os
+import math
+from typing import List, Dict
+
+import pandas as pd
+import yfinance as yf
+from telegram import Bot
+
+
+def predict_index_movement(shortlisted_count: int, threshold: int = 10) -> float:
+    """Estimate probability of index up move using logistic function."""
+    return 1 / (1 + math.exp(-(shortlisted_count - threshold) / 5))
+
+
+def _pct_change(symbol: str) -> float:
+    df = yf.download(symbol, period="2d", interval="1d", progress=False)
+    if df.empty or len(df) < 2:
+        return 0.0
+    return df["Close"].iloc[-1] / df["Close"].iloc[0] - 1
+
+
+def compare_with_indices(symbols: List[str]) -> Dict[str, float]:
+    """Compare average stock change with NIFTY50 and BankNifty indices."""
+    changes = []
+    for sym in symbols:
+        df = yf.download(f"{sym}.NS", period="2d", interval="1d", progress=False)
+        if df.empty or len(df) < 2:
+            continue
+        changes.append(df["Close"].iloc[-1] / df["Close"].iloc[0] - 1)
+    avg_change = sum(changes) / len(changes) if changes else 0.0
+    return {
+        "stocks": avg_change,
+        "nifty": _pct_change("^NSEI"),
+        "banknifty": _pct_change("^NSEBANK"),
+    }
+
+
+def send_telegram_message(message: str) -> None:
+    """Send a message via Telegram using token and chat id env vars."""
+    token = os.getenv("TELEGRAM_TOKEN")
+    chat_id = os.getenv("TELEGRAM_CHAT_ID")
+    if not token or not chat_id:
+        return
+    bot = Bot(token=token)
+    bot.send_message(chat_id=chat_id, text=message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ yfinance
 pandas
 numpy
 tqdm
+python-telegram-bot

--- a/run_scan.py
+++ b/run_scan.py
@@ -7,12 +7,17 @@ from nse_fno_scanner.fetch_fno_list import fetch_fno_list
 from nse_fno_scanner.dma_filter import filter_by_dma
 from nse_fno_scanner.intraday_scanner import intraday_scan
 from nse_fno_scanner.backtester import backtest_strategy
+from nse_fno_scanner.market_predictor import (
+    predict_index_movement,
+    compare_with_indices,
+    send_telegram_message,
+)
 
 
 DEFAULT_LOG = Path("scan_results.txt")
 
 
-def run(output: Path = DEFAULT_LOG, backtest: bool = False) -> None:
+def run(output: Path = DEFAULT_LOG, backtest: bool = False, notify: bool = False) -> None:
     symbols = fetch_fno_list()
     symbols = filter_by_dma(symbols)
     results = intraday_scan(symbols)
@@ -28,6 +33,17 @@ def run(output: Path = DEFAULT_LOG, backtest: bool = False) -> None:
             trades, win_rate, avg_ret = backtest_strategy(sym)
             print(f"{sym}: trades={trades}, win_rate={win_rate:.1f}%, avg_return={avg_ret:.2f}%")
 
+    if notify:
+        prob = predict_index_movement(len(results))
+        comp = compare_with_indices(results)
+        msg = (
+            f"Shortlisted {len(results)} stocks. "
+            f"Market up probability: {prob:.1%}\n"
+            f"Avg stock change: {comp['stocks']:.2%}\n"
+            f"NIFTY50: {comp['nifty']:.2%}, BankNifty: {comp['banknifty']:.2%}"
+        )
+        send_telegram_message(msg)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="NSE F&O bullish setup scanner")
@@ -42,8 +58,25 @@ def main() -> None:
         action="store_true",
         help="Run simple backtest for shortlisted stocks",
     )
+    parser.add_argument(
+        "--notify",
+        action="store_true",
+        help="Send Telegram notifications",
+    )
+    parser.add_argument(
+        "--schedule",
+        action="store_true",
+        help="Run scan every 15 minutes",
+    )
     args = parser.parse_args()
-    run(args.output, args.backtest)
+    if args.schedule:
+        import time
+
+        while True:
+            run(args.output, args.backtest, args.notify)
+            time.sleep(900)
+    else:
+        run(args.output, args.backtest, args.notify)
 
 
 if __name__ == "__main__":

--- a/tests/test_market_predictor.py
+++ b/tests/test_market_predictor.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import pandas as pd
+import yfinance as yf
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nse_fno_scanner.market_predictor import (
+    predict_index_movement,
+    compare_with_indices,
+    send_telegram_message,
+)
+
+
+def test_predict_index_movement_range():
+    assert 0.0 < predict_index_movement(0) < 1.0
+    high = predict_index_movement(20)
+    low = predict_index_movement(0)
+    assert high > low
+
+
+def test_compare_with_indices(monkeypatch):
+    data_map = {
+        "^NSEI": pd.DataFrame({"Close": [100, 110]}),
+        "^NSEBANK": pd.DataFrame({"Close": [200, 220]}),
+        "TEST.NS": pd.DataFrame({"Close": [50, 55]}),
+    }
+
+    def fake_download(symbol, *args, **kwargs):
+        return data_map.get(symbol, data_map["TEST.NS"])
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    res = compare_with_indices(["TEST"])
+    assert res["nifty"] > 0
+    assert res["banknifty"] > 0
+    assert res["stocks"] > 0
+
+
+def test_send_telegram_message(monkeypatch):
+    sent = {}
+
+    class FakeBot:
+        def __init__(self, token):
+            sent["token"] = token
+
+        def send_message(self, chat_id, text):
+            sent["chat_id"] = chat_id
+            sent["text"] = text
+
+    monkeypatch.setattr("nse_fno_scanner.market_predictor.Bot", FakeBot)
+    monkeypatch.setenv("TELEGRAM_TOKEN", "tkn")
+    monkeypatch.setenv("TELEGRAM_CHAT_ID", "cid")
+    send_telegram_message("hello")
+    assert sent["token"] == "tkn"
+    assert sent["chat_id"] == "cid"
+    assert sent["text"] == "hello"

--- a/tests/test_run_scan.py
+++ b/tests/test_run_scan.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import run_scan
+
+
+def test_run_with_notify(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_scan, "fetch_fno_list", lambda: ["A"])
+    monkeypatch.setattr(run_scan, "filter_by_dma", lambda syms: syms)
+    monkeypatch.setattr(run_scan, "intraday_scan", lambda syms: ["A"])
+    monkeypatch.setattr(run_scan, "backtest_strategy", lambda sym: (0, 0.0, 0.0))
+
+    sent = {}
+    def fake_send(msg):
+        sent["msg"] = msg
+    monkeypatch.setattr(run_scan, "send_telegram_message", fake_send)
+    monkeypatch.setattr(run_scan, "predict_index_movement", lambda c: 0.5)
+    monkeypatch.setattr(run_scan, "compare_with_indices", lambda syms: {"stocks":0.01,"nifty":0.02,"banknifty":0.03})
+
+    out = tmp_path / "out.txt"
+    run_scan.run(out, backtest=False, notify=True)
+    assert "Market up" in sent["msg"]


### PR DESCRIPTION
## Summary
- implement market prediction helper with Telegram messaging
- schedule scans with periodic Telegram updates
- add requirements for python-telegram-bot
- test market prediction functions and scheduled scan logic

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865609b43208320a04348619fb0487a