### PR TITLE
Add Colab notebook and usage docs

### DIFF
--- a/NiftyStocks_Colab.ipynb
+++ b/NiftyStocks_Colab.ipynb
@@ -1,0 +1,74 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NiftyStocks Colab Setup\n",
+    "This notebook installs NiftyStocks and runs the scanner."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Clone the repository (replace URL if forked)\n",
+    "!git clone https://github.com/Santalgo/NiftyStocks.git && cd NiftyStocks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Install dependencies\n",
+    "!pip install -q -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set `TELEGRAM_TOKEN` and `TELEGRAM_CHAT_ID` as environment variables if you want notifications." 
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Example: enable Telegram (optional)\n",
+    "import os\n",
+    "os.environ['TELEGRAM_TOKEN'] = 'your-bot-token'\n",
+    "os.environ['TELEGRAM_CHAT_ID'] = 'target-chat-id'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Run the scanner\n",
+    "!python run_scan.py --notify"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ Run the scanner with notifications enabled:
 ```bash
 python run_scan.py --notify
 ```
+
+## Google Colab
+
+You can try the scanner in the browser using
+[Google Colab](https://colab.research.google.com/). A ready-to-run notebook is
+provided in `NiftyStocks_Colab.ipynb`.
+Open the notebook on Colab, execute the setup cells to install dependencies and
+optionally set the Telegram environment variables, then run the final cell to
+start the scan.


### PR DESCRIPTION
## Summary
- add a `NiftyStocks_Colab.ipynb` notebook with setup cells for running the scanner on Google Colab
- document Colab usage in the README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865632f5edc832086cde9f46119cf64