### PR TITLE
Add ticker selection and debugging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,30 @@ Run the scanner with notifications enabled:
 python run_scan.py --notify
 ```
 
+Additional options are available:
+
+```
+--symbols  Comma separated tickers to scan instead of full F&O list
+--fno-url  Custom CSV URL for the F&O stock list
+--debug    Enable debug logging output
+```
+
+The ``--fno-url`` option also accepts plain text lists with one ticker per line,
+such as the list shared at:
+
+```
+https://drive.google.com/file/d/1f26r2NEPmMkZTBuh1yxoRBGsOhNoxynV/view?usp=sharing
+```
+
+Debug messages are printed to the console. For quick printf-style messages
+within your own scripts you can use `nse_fno_scanner.printf`:
+
+```python
+from nse_fno_scanner import printf
+
+printf("Scanning %s symbols", len(symbols))
+```
+
 ## Google Colab
 
 You can try the scanner in the browser using

--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -9,6 +9,7 @@ from .market_predictor import (
     compare_with_indices,
     send_telegram_message,
 )
+from .utils import printf
 
 __all__ = [
     "fetch_fno_list",
@@ -18,4 +19,5 @@ __all__ = [
     "predict_index_movement",
     "compare_with_indices",
     "send_telegram_message",
+    "printf",
 ]

--- a/nse_fno_scanner/fetch_fno_list.py
+++ b/nse_fno_scanner/fetch_fno_list.py
@@ -2,26 +2,35 @@
 
 from typing import List
 
+import logging
+
 import pandas as pd
 
 FNO_LIST_URL = "https://archives.nseindia.com/content/fo/fo_mktlots.csv"
 
+logger = logging.getLogger(__name__)
 
-def fetch_fno_list() -> List[str]:
-    """Download the official NSE F&O stock list and return equity symbols.
+
+def fetch_fno_list(url: str = FNO_LIST_URL) -> List[str]:
+    """Download the NSE F&O stock list from ``url`` and return equity symbols.
 
     Returns
     -------
     List[str]
         List of equity ticker symbols available in F&O segment.
     """
+    logger.debug("Downloading F&O list from %s", url)
     try:
-        df = pd.read_csv(FNO_LIST_URL)
+        df = pd.read_csv(url)
     except Exception as exc:
         raise RuntimeError(f"Failed to fetch F&O list: {exc}") from exc
 
-    if "SYMBOL" not in df.columns:
+    if "SYMBOL" in df.columns:
+        col = df["SYMBOL"]
+    elif len(df.columns) == 1:
+        col = df.iloc[:, 0]
+    else:
         raise ValueError("CSV does not contain SYMBOL column")
 
-    symbols = df["SYMBOL"].dropna().astype(str).unique().tolist()
+    symbols = col.dropna().astype(str).unique().tolist()
     return symbols

--- a/nse_fno_scanner/intraday_scanner.py
+++ b/nse_fno_scanner/intraday_scanner.py
@@ -2,9 +2,13 @@
 
 from typing import Iterable, List
 
+import logging
+
 import pandas as pd
 import yfinance as yf
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
 
 
 def compute_emas(data: pd.DataFrame) -> pd.DataFrame:
@@ -29,13 +33,15 @@ def intraday_scan(symbols: Iterable[str]) -> List[str]:
     shortlisted = []
     for symbol in tqdm(list(symbols), desc="Intraday scan"):
         try:
+            logger.debug("Downloading intraday data for %s", symbol)
             df = yf.download(
                 f"{symbol}.NS",
                 period="3d",
                 interval="15m",
                 progress=False,
             )
-        except Exception:
+        except Exception as exc:
+            logger.debug("Failed to download %s: %s", symbol, exc)
             continue
         if df.empty or len(df) < 50:
             continue
@@ -43,4 +49,5 @@ def intraday_scan(symbols: Iterable[str]) -> List[str]:
         last_row = df.iloc[-1]
         if last_row["EMA20"] >= last_row["EMA50"] and pattern_confirmed(df):
             shortlisted.append(symbol)
+            logger.debug("%s passed intraday scan", symbol)
     return shortlisted

--- a/nse_fno_scanner/market_predictor.py
+++ b/nse_fno_scanner/market_predictor.py
@@ -2,9 +2,13 @@ import os
 import math
 from typing import List, Dict
 
+import logging
+
 import pandas as pd
 import yfinance as yf
 from telegram import Bot
+
+logger = logging.getLogger(__name__)
 
 
 def predict_index_movement(shortlisted_count: int, threshold: int = 10) -> float:
@@ -13,6 +17,7 @@ def predict_index_movement(shortlisted_count: int, threshold: int = 10) -> float
 
 
 def _pct_change(symbol: str) -> float:
+    logger.debug("Downloading index data for %s", symbol)
     df = yf.download(symbol, period="2d", interval="1d", progress=False)
     if df.empty or len(df) < 2:
         return 0.0
@@ -23,6 +28,7 @@ def compare_with_indices(symbols: List[str]) -> Dict[str, float]:
     """Compare average stock change with NIFTY50 and BankNifty indices."""
     changes = []
     for sym in symbols:
+        logger.debug("Downloading change data for %s", sym)
         df = yf.download(f"{sym}.NS", period="2d", interval="1d", progress=False)
         if df.empty or len(df) < 2:
             continue

--- a/nse_fno_scanner/utils.py
+++ b/nse_fno_scanner/utils.py
@@ -1,0 +1,9 @@
+"""Helper utilities."""
+
+from __future__ import annotations
+
+
+def printf(fmt: str, *args, flush: bool = True) -> None:
+    """Print formatted message to stdout, similar to C printf."""
+    print(fmt % args if args else fmt, flush=flush)
+

--- a/run_scan.py
+++ b/run_scan.py
@@ -1,9 +1,10 @@
 """CLI entry point for running the F&O bullish setup scanner."""
 import argparse
+import logging
 from pathlib import Path
 
 
-from nse_fno_scanner.fetch_fno_list import fetch_fno_list
+from nse_fno_scanner.fetch_fno_list import fetch_fno_list, FNO_LIST_URL
 from nse_fno_scanner.dma_filter import filter_by_dma
 from nse_fno_scanner.intraday_scanner import intraday_scan
 from nse_fno_scanner.backtester import backtest_strategy
@@ -17,9 +18,34 @@ from nse_fno_scanner.market_predictor import (
 DEFAULT_LOG = Path("scan_results.txt")
 
 
-def run(output: Path = DEFAULT_LOG, backtest: bool = False, notify: bool = False) -> None:
-    symbols = fetch_fno_list()
+def _parse_symbols(text: str | None) -> list[str] | None:
+    """Parse comma separated symbols string into a list."""
+    if not text:
+        return None
+    return [s.strip().upper() for s in text.split(",") if s.strip()]
+
+
+def run(
+    output: Path = DEFAULT_LOG,
+    backtest: bool = False,
+    notify: bool = False,
+    symbols: list[str] | None = None,
+    fno_url: str | None = None,
+    debug: bool = False,
+) -> None:
+    """Run the scan and optionally notify/backtest."""
+
+    logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
+
+    if symbols is None:
+        logging.debug("Fetching F&O list")
+        if fno_url:
+            symbols = fetch_fno_list(url=fno_url)
+        else:
+            symbols = fetch_fno_list()
+    logging.debug("Filtering %d symbols by DMA", len(symbols))
     symbols = filter_by_dma(symbols)
+    logging.debug("Running intraday scan on %d symbols", len(symbols))
     results = intraday_scan(symbols)
 
     output.write_text("\n".join(results))
@@ -31,7 +57,9 @@ def run(output: Path = DEFAULT_LOG, backtest: bool = False, notify: bool = False
         print("\nBacktest results:")
         for sym in results:
             trades, win_rate, avg_ret = backtest_strategy(sym)
-            print(f"{sym}: trades={trades}, win_rate={win_rate:.1f}%, avg_return={avg_ret:.2f}%")
+            print(
+                f"{sym}: trades={trades}, win_rate={win_rate:.1f}%, avg_return={avg_ret:.2f}%"
+            )
 
     if notify:
         prob = predict_index_movement(len(results))
@@ -68,15 +96,42 @@ def main() -> None:
         action="store_true",
         help="Run scan every 15 minutes",
     )
+    parser.add_argument(
+        "--symbols",
+        help="Comma separated list of ticker symbols to scan",
+    )
+    parser.add_argument(
+        "--fno-url",
+        help="Custom URL to download F&O stock list",
+    )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging",
+    )
     args = parser.parse_args()
     if args.schedule:
         import time
 
         while True:
-            run(args.output, args.backtest, args.notify)
+            run(
+                args.output,
+                args.backtest,
+                args.notify,
+                symbols=_parse_symbols(args.symbols),
+                fno_url=args.fno_url,
+                debug=args.debug,
+            )
             time.sleep(900)
     else:
-        run(args.output, args.backtest, args.notify)
+        run(
+            args.output,
+            args.backtest,
+            args.notify,
+            symbols=_parse_symbols(args.symbols),
+            fno_url=args.fno_url,
+            debug=args.debug,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,6 +3,7 @@ from nse_fno_scanner import (
     filter_by_dma,
     intraday_scan,
     backtest_strategy,
+    printf,
 )
 
 
@@ -11,3 +12,4 @@ def test_root_exports_callable():
     assert callable(filter_by_dma)
     assert callable(intraday_scan)
     assert callable(backtest_strategy)
+    assert callable(printf)

--- a/tests/test_fetch_fno_list.py
+++ b/tests/test_fetch_fno_list.py
@@ -1,0 +1,24 @@
+import pandas as pd
+from nse_fno_scanner.fetch_fno_list import fetch_fno_list
+
+
+def test_custom_url(monkeypatch):
+    data = pd.DataFrame({"SYMBOL": ["AAA", "BBB"]})
+
+    def fake_read_csv(url):
+        assert url == "http://example.com/fno.csv"
+        return data
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    symbols = fetch_fno_list("http://example.com/fno.csv")
+    assert symbols == ["AAA", "BBB"]
+
+
+def test_plain_list(monkeypatch):
+    data = pd.DataFrame({0: ["AAA", "BBB"]})
+
+    def fake_read_csv(url):
+        return data
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    assert fetch_fno_list("http://example.com/list.csv") == ["AAA", "BBB"]


### PR DESCRIPTION
## Summary
- support custom F&O list URL and ticker selection
- add optional debug logging across modules
- add `printf` helper for on-screen debugging
- handle simple one-column ticker lists
- document new helper and update tests

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68669682fe1c8320802a5127fc3fe745