### PR TITLE
Add local F&O list reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Additional options are available:
 --debug    Enable debug logging output
 ```
 
+If a file named `fno_list.csv` is present in the project directory it will
+be used as the default F&O list, avoiding any downloads.
+
 The ``--fno-url`` option also accepts plain text lists with one ticker per line,
 such as the list shared at:
 

--- a/nse_fno_scanner/fetch_fno_list.py
+++ b/nse_fno_scanner/fetch_fno_list.py
@@ -1,6 +1,7 @@
 """Retrieve the official NSE F&O equity symbol list."""
 
 from typing import List
+from pathlib import Path
 
 import logging
 
@@ -11,6 +12,7 @@ import os
 import gdown
 
 FNO_LIST_URL = "https://archives.nseindia.com/content/fo/fo_mktlots.csv"
+FNO_LOCAL_PATH = Path(__file__).resolve().parents[1] / "fno_list.csv"
 
 logger = logging.getLogger(__name__)
 
@@ -38,14 +40,19 @@ def fetch_fno_list(url: str = FNO_LIST_URL) -> List[str]:
     List[str]
         List of equity ticker symbols available in F&O segment.
     """
-    logger.debug("Downloading F&O list from %s", url)
-    local_path = _maybe_download_google_drive(url)
-    try:
-        df = pd.read_csv(local_path)
-        if local_path != url and os.path.exists(local_path):
-            os.unlink(local_path)
-    except Exception as exc:
-        raise RuntimeError(f"Failed to fetch F&O list: {exc}") from exc
+
+    if url == FNO_LIST_URL and FNO_LOCAL_PATH.exists():
+        logger.debug("Loading F&O list from %s", FNO_LOCAL_PATH)
+        df = pd.read_csv(FNO_LOCAL_PATH, header=None, names=["SYMBOL"])
+    else:
+        logger.debug("Downloading F&O list from %s", url)
+        local_path = _maybe_download_google_drive(url)
+        try:
+            df = pd.read_csv(local_path)
+            if local_path != url and os.path.exists(local_path):
+                os.unlink(local_path)
+        except Exception as exc:
+            raise RuntimeError(f"Failed to fetch F&O list: {exc}") from exc
 
     if "SYMBOL" in df.columns:
         col = df["SYMBOL"]

--- a/tests/test_fetch_fno_list.py
+++ b/tests/test_fetch_fno_list.py
@@ -1,5 +1,8 @@
 import pandas as pd
+import importlib
 from nse_fno_scanner.fetch_fno_list import fetch_fno_list
+
+fetch_module = importlib.import_module("nse_fno_scanner.fetch_fno_list")
 
 
 def test_custom_url(monkeypatch):
@@ -22,3 +25,17 @@ def test_plain_list(monkeypatch):
 
     monkeypatch.setattr(pd, "read_csv", fake_read_csv)
     assert fetch_fno_list("http://example.com/list.csv") == ["AAA", "BBB"]
+
+
+def test_local_file(monkeypatch, tmp_path):
+    path = tmp_path / "fno_list.csv"
+    path.write_text("AAA\nBBB\n")
+
+    monkeypatch.setattr(fetch_module, "FNO_LOCAL_PATH", path)
+
+    def fake_read_csv(p, *args, **kwargs):
+        assert p == path
+        return pd.DataFrame({"SYMBOL": ["AAA", "BBB"]})
+
+    monkeypatch.setattr(pd, "read_csv", fake_read_csv)
+    assert fetch_fno_list() == ["AAA", "BBB"]


### PR DESCRIPTION
## Summary
- allow `fetch_fno_list` to read `fno_list.csv` if present
- document local F&O list usage
- test reading from the local CSV

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866ac3d4db48320a4ce3fc35736e6c9