### PR TITLE
Handle multi-level columns from yfinance

### DIFF
--- a/nse_fno_scanner/backtester.py
+++ b/nse_fno_scanner/backtester.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import logging
 
 import yfinance as yf
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,15 @@ def backtest_strategy(symbol: str, period: str = "6mo") -> Tuple[int, float, flo
     """
     try:
         logger.debug("Downloading backtest data for %s", symbol)
-        df = yf.download(f"{symbol}.NS", period=period, interval="1d", progress=False)
+        df = yf.download(
+            f"{symbol}.NS",
+            period=period,
+            interval="1d",
+            progress=False,
+            multi_level_index=False,
+        )
+        if isinstance(df.columns, pd.MultiIndex):
+            df.columns = df.columns.get_level_values(0)
     except Exception as exc:
         logger.debug("Failed to download %s: %s", symbol, exc)
         return 0, 0.0, 0.0

--- a/nse_fno_scanner/dma_filter.py
+++ b/nse_fno_scanner/dma_filter.py
@@ -25,7 +25,15 @@ def filter_by_dma(symbols: Iterable[str], offset: int = 1) -> List[str]:
     for symbol in tqdm(list(symbols), desc="DMA filter"):
         try:
             logger.debug("Downloading daily data for %s", symbol)
-            df = yf.download(f"{symbol}.NS", period="300d", interval="1d", progress=False)
+            df = yf.download(
+                f"{symbol}.NS",
+                period="300d",
+                interval="1d",
+                progress=False,
+                multi_level_index=False,
+            )
+            if isinstance(df.columns, pd.MultiIndex):
+                df.columns = df.columns.get_level_values(0)
         except Exception as exc:
             logger.debug("Failed to download %s: %s", symbol, exc)
             continue

--- a/nse_fno_scanner/intraday_scanner.py
+++ b/nse_fno_scanner/intraday_scanner.py
@@ -39,7 +39,10 @@ def intraday_scan(symbols: Iterable[str]) -> List[str]:
                 period="3d",
                 interval="15m",
                 progress=False,
+                multi_level_index=False,
             )
+            if isinstance(df.columns, pd.MultiIndex):
+                df.columns = df.columns.get_level_values(0)
         except Exception as exc:
             logger.debug("Failed to download %s: %s", symbol, exc)
             continue

--- a/nse_fno_scanner/market_predictor.py
+++ b/nse_fno_scanner/market_predictor.py
@@ -18,7 +18,15 @@ def predict_index_movement(shortlisted_count: int, threshold: int = 10) -> float
 
 def _pct_change(symbol: str) -> float:
     logger.debug("Downloading index data for %s", symbol)
-    df = yf.download(symbol, period="2d", interval="1d", progress=False)
+    df = yf.download(
+        symbol,
+        period="2d",
+        interval="1d",
+        progress=False,
+        multi_level_index=False,
+    )
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
     if df.empty or len(df) < 2:
         return 0.0
     return df["Close"].iloc[-1] / df["Close"].iloc[0] - 1
@@ -29,7 +37,15 @@ def compare_with_indices(symbols: List[str]) -> Dict[str, float]:
     changes = []
     for sym in symbols:
         logger.debug("Downloading change data for %s", sym)
-        df = yf.download(f"{sym}.NS", period="2d", interval="1d", progress=False)
+        df = yf.download(
+            f"{sym}.NS",
+            period="2d",
+            interval="1d",
+            progress=False,
+            multi_level_index=False,
+        )
+        if isinstance(df.columns, pd.MultiIndex):
+            df.columns = df.columns.get_level_values(0)
         if df.empty or len(df) < 2:
             continue
         changes.append(df["Close"].iloc[-1] / df["Close"].iloc[0] - 1)

--- a/tests/test_dma_filter.py
+++ b/tests/test_dma_filter.py
@@ -1,10 +1,11 @@
 import os
 import sys
 import pandas as pd
+import yfinance as yf
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from nse_fno_scanner.dma_filter import compute_dmas
+from nse_fno_scanner.dma_filter import compute_dmas, filter_by_dma
 
 
 def test_compute_dmas():
@@ -14,3 +15,16 @@ def test_compute_dmas():
     assert not df["200DMA"].isna().all()
     last = df.iloc[-1]
     assert last["50DMA"] > last["200DMA"]
+
+
+def test_filter_by_dma_handles_multiindex(monkeypatch):
+    dates = pd.date_range("2020-01-01", periods=300)
+    close = pd.Series(range(1, 301), index=dates)
+    data = pd.DataFrame({("Close", "TEST"): close, ("Open", "TEST"): close})
+
+    def fake_download(*args, **kwargs):
+        return data
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    out = filter_by_dma(["TEST"], offset=1)
+    assert out == ["TEST"]


### PR DESCRIPTION
## Summary
- flatten yfinance downloads across the project
- ensure backtester and predictors support single-level columns
- test DMA filtering with multiindex data

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866b2869d6c83209df5a65c5ed2e1f7