### PR TITLE
Enhanced DMA scan controls

### DIFF
--- a/nse_fno_scanner/dma_filter.py
+++ b/nse_fno_scanner/dma_filter.py
@@ -1,4 +1,4 @@
-"""Utilities for filtering stocks using daily moving averages."""
+"""Utilities for filtering stocks using daily and intraday moving averages."""
 
 from typing import Iterable, List
 
@@ -8,27 +8,66 @@ import pandas as pd
 import yfinance as yf
 from tqdm import tqdm
 
+from .intraday_scanner import compute_emas, pattern_confirmed
+
 logger = logging.getLogger(__name__)
 
 
-def compute_dmas(data: pd.DataFrame) -> pd.DataFrame:
-    """Compute 50 and 200 day simple moving averages."""
+def compute_dmas(data: pd.DataFrame, fast: int = 20, slow: int = 50) -> pd.DataFrame:
+    """Compute exponential moving averages for the given periods."""
+
     df = data.copy()
-    df["50DMA"] = df["Close"].rolling(window=50).mean()
-    df["200DMA"] = df["Close"].rolling(window=200).mean()
+    df[f"EMA{fast}"] = df["Close"].ewm(span=fast, adjust=False).mean()
+    df[f"EMA{slow}"] = df["Close"].ewm(span=slow, adjust=False).mean()
     return df
 
 
-def filter_by_dma(symbols: Iterable[str], offset: int = 1) -> List[str]:
-    """Filter symbols where 50DMA > 200DMA using last ``offset`` days excluded."""
+def filter_by_dma(
+    symbols: Iterable[str],
+    offset: int = 1,
+    *,
+    fast_period: int = 20,
+    slow_period: int = 50,
+    higher_interval: str = "1d",
+    lower_interval: str = "15m",
+    higher_period: str = "100d",
+    lower_period: str = "3d",
+) -> List[str]:
+    """Filter symbols using daily and intraday moving averages.
+
+    Parameters
+    ----------
+    symbols : Iterable[str]
+        Ticker symbols to evaluate.
+    offset : int, optional
+        Number of latest higher timeframe candles to ignore when checking
+        moving averages.
+    fast_period : int, optional
+        Period for the fast EMA. Defaults to ``20``.
+    slow_period : int, optional
+        Period for the slow EMA. Defaults to ``50``.
+    higher_interval : str, optional
+        Time interval for the higher timeframe download. Defaults to ``1d``.
+    lower_interval : str, optional
+        Time interval for the lower timeframe download. Defaults to ``15m``.
+    higher_period : str, optional
+        Historical period for the higher timeframe download. Defaults to ``100d``.
+    lower_period : str, optional
+        Historical period for the lower timeframe download. Defaults to ``3d``.
+
+    Returns
+    -------
+    List[str]
+        Symbols passing both daily and intraday conditions.
+    """
     shortlisted = []
     for symbol in tqdm(list(symbols), desc="DMA filter"):
         try:
             logger.debug("Downloading daily data for %s", symbol)
             df = yf.download(
                 f"{symbol}.NS",
-                period="300d",
-                interval="1d",
+                period=higher_period,
+                interval=higher_interval,
                 progress=False,
                 multi_level_index=False,
             )
@@ -37,11 +76,36 @@ def filter_by_dma(symbols: Iterable[str], offset: int = 1) -> List[str]:
         except Exception as exc:
             logger.debug("Failed to download %s: %s", symbol, exc)
             continue
-        if df.empty or len(df) < 200 + offset:
+        if df.empty or len(df) < slow_period + offset:
             continue
-        df = compute_dmas(df)
+        df = compute_dmas(df, fast=fast_period, slow=slow_period)
         row = df.iloc[-(offset + 1)]  # exclude recent `offset` days
-        if row["50DMA"] > row["200DMA"]:
+        if row[f"EMA{fast_period}"] <= row[f"EMA{slow_period}"]:
+            continue
+
+        try:
+            logger.debug("Downloading intraday data for %s", symbol)
+            intra = yf.download(
+                f"{symbol}.NS",
+                period=lower_period,
+                interval=lower_interval,
+                progress=False,
+                multi_level_index=False,
+            )
+            if isinstance(intra.columns, pd.MultiIndex):
+                intra.columns = intra.columns.get_level_values(0)
+        except Exception as exc:
+            logger.debug("Failed to download intraday %s: %s", symbol, exc)
+            continue
+        if intra.empty or len(intra) < slow_period:
+            continue
+
+        intra = compute_emas(intra, fast=fast_period, slow=slow_period)
+        last_row = intra.iloc[-1]
+        if (
+            last_row[f"EMA{fast_period}"] >= last_row[f"EMA{slow_period}"]
+            and pattern_confirmed(intra)
+        ):
             shortlisted.append(symbol)
             logger.debug("%s passed DMA filter", symbol)
     return shortlisted

--- a/nse_fno_scanner/intraday_scanner.py
+++ b/nse_fno_scanner/intraday_scanner.py
@@ -11,10 +11,22 @@ from tqdm import tqdm
 logger = logging.getLogger(__name__)
 
 
-def compute_emas(data: pd.DataFrame) -> pd.DataFrame:
+def compute_emas(data: pd.DataFrame, fast: int = 20, slow: int = 50) -> pd.DataFrame:
+    """Return ``data`` with exponential moving averages added.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Data containing ``Close`` prices.
+    fast : int, optional
+        Period for the fast EMA. Defaults to ``20``.
+    slow : int, optional
+        Period for the slow EMA. Defaults to ``50``.
+    """
+
     df = data.copy()
-    df["EMA20"] = df["Close"].ewm(span=20, adjust=False).mean()
-    df["EMA50"] = df["Close"].ewm(span=50, adjust=False).mean()
+    df[f"EMA{fast}"] = df["Close"].ewm(span=fast, adjust=False).mean()
+    df[f"EMA{slow}"] = df["Close"].ewm(span=slow, adjust=False).mean()
     return df
 
 

--- a/run_scan.py
+++ b/run_scan.py
@@ -32,8 +32,29 @@ def run(
     symbols: list[str] | None = None,
     fno_url: str | None = None,
     debug: bool = False,
-) -> None:
-    """Run the scan and optionally notify/backtest."""
+    fast: int = 20,
+    slow: int = 50,
+    higher_int: str = "1d",
+    lower_int: str = "15m",
+) -> list[str]:
+    """Run the scan and optionally notify/backtest.
+
+    Parameters
+    ----------
+    fast : int, optional
+        Fast EMA period for moving average checks.
+    slow : int, optional
+        Slow EMA period for moving average checks.
+    higher_int : str, optional
+        Interval for higher timeframe data.
+    lower_int : str, optional
+        Interval for lower timeframe data.
+
+    Returns
+    -------
+    list[str]
+        Symbols that passed the scan.
+    """
 
     logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
 
@@ -44,7 +65,13 @@ def run(
         else:
             symbols = fetch_fno_list()
     logging.debug("Filtering %d symbols by DMA", len(symbols))
-    symbols = filter_by_dma(symbols)
+    symbols = filter_by_dma(
+        symbols,
+        fast_period=fast,
+        slow_period=slow,
+        higher_interval=higher_int,
+        lower_interval=lower_int,
+    )
     logging.debug("Running intraday scan on %d symbols", len(symbols))
     results = intraday_scan(symbols)
 
@@ -72,6 +99,25 @@ def run(
         )
         send_telegram_message(msg)
 
+    return results
+
+
+def schedule_scan(freq_minutes: int = 15, **kwargs) -> None:
+    """Run :func:`run` periodically and print market prediction.
+
+    Parameters
+    ----------
+    freq_minutes : int, optional
+        Number of minutes between runs.
+    """
+    import time
+
+    while True:
+        results = run(**kwargs)
+        prob = predict_index_movement(len(results))
+        print(f"Predicted market up move probability: {prob:.1%}")
+        time.sleep(freq_minutes * 60)
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="NSE F&O bullish setup scanner")
@@ -97,6 +143,34 @@ def main() -> None:
         help="Run scan every 15 minutes",
     )
     parser.add_argument(
+        "--fast",
+        type=int,
+        default=20,
+        help="Fast EMA period",
+    )
+    parser.add_argument(
+        "--slow",
+        type=int,
+        default=50,
+        help="Slow EMA period",
+    )
+    parser.add_argument(
+        "--higher-int",
+        default="1d",
+        help="Interval for higher timeframe (e.g. 1d)",
+    )
+    parser.add_argument(
+        "--lower-int",
+        default="15m",
+        help="Interval for lower timeframe (e.g. 15m)",
+    )
+    parser.add_argument(
+        "--freq",
+        type=int,
+        default=15,
+        help="Minutes between scheduled runs",
+    )
+    parser.add_argument(
         "--symbols",
         help="Comma separated list of ticker symbols to scan",
     )
@@ -111,18 +185,19 @@ def main() -> None:
     )
     args = parser.parse_args()
     if args.schedule:
-        import time
-
-        while True:
-            run(
-                args.output,
-                args.backtest,
-                args.notify,
-                symbols=_parse_symbols(args.symbols),
-                fno_url=args.fno_url,
-                debug=args.debug,
-            )
-            time.sleep(900)
+        schedule_scan(
+            freq_minutes=args.freq,
+            output=args.output,
+            backtest=args.backtest,
+            notify=args.notify,
+            symbols=_parse_symbols(args.symbols),
+            fno_url=args.fno_url,
+            debug=args.debug,
+            fast=args.fast,
+            slow=args.slow,
+            higher_int=args.higher_int,
+            lower_int=args.lower_int,
+        )
     else:
         run(
             args.output,
@@ -131,6 +206,10 @@ def main() -> None:
             symbols=_parse_symbols(args.symbols),
             fno_url=args.fno_url,
             debug=args.debug,
+            fast=args.fast,
+            slow=args.slow,
+            higher_int=args.higher_int,
+            lower_int=args.lower_int,
         )
 
 

--- a/tests/test_dma_filter.py
+++ b/tests/test_dma_filter.py
@@ -9,21 +9,28 @@ from nse_fno_scanner.dma_filter import compute_dmas, filter_by_dma
 
 
 def test_compute_dmas():
-    data = pd.DataFrame({"Close": range(1, 301)})
+    data = pd.DataFrame({"Close": range(1, 61)})
     df = compute_dmas(data)
-    assert not df["50DMA"].isna().all()
-    assert not df["200DMA"].isna().all()
+    assert "EMA20" in df.columns and "EMA50" in df.columns
+    assert not df["EMA20"].isna().all()
+    assert not df["EMA50"].isna().all()
     last = df.iloc[-1]
-    assert last["50DMA"] > last["200DMA"]
+    assert last["EMA20"] > last["EMA50"]
 
 
 def test_filter_by_dma_handles_multiindex(monkeypatch):
-    dates = pd.date_range("2020-01-01", periods=300)
-    close = pd.Series(range(1, 301), index=dates)
-    data = pd.DataFrame({("Close", "TEST"): close, ("Open", "TEST"): close})
+    dates = pd.date_range("2020-01-01", periods=60)
+    close = pd.Series(range(1, 61), index=dates)
+    daily = pd.DataFrame({("Close", "TEST"): close, ("Open", "TEST"): close})
 
-    def fake_download(*args, **kwargs):
-        return data
+    idates = pd.date_range("2020-03-01", periods=60, freq="15T")
+    iclose = pd.Series(range(1, 61), index=idates)
+    intraday = pd.DataFrame({("Close", "TEST"): iclose})
+
+    def fake_download(symbol, *args, **kwargs):
+        if kwargs.get("interval") == "1d":
+            return daily
+        return intraday
 
     monkeypatch.setattr(yf, "download", fake_download)
     out = filter_by_dma(["TEST"], offset=1)

--- a/tests/test_run_scan.py
+++ b/tests/test_run_scan.py
@@ -8,7 +8,7 @@ import run_scan
 
 def test_run_with_notify(monkeypatch, tmp_path):
     monkeypatch.setattr(run_scan, "fetch_fno_list", lambda: ["A"])
-    monkeypatch.setattr(run_scan, "filter_by_dma", lambda syms: syms)
+    monkeypatch.setattr(run_scan, "filter_by_dma", lambda syms, **kw: syms)
     monkeypatch.setattr(run_scan, "intraday_scan", lambda syms: ["A"])
     monkeypatch.setattr(run_scan, "backtest_strategy", lambda sym: (0, 0.0, 0.0))
 


### PR DESCRIPTION
## Summary
- switch daily averages to EMA and expose fast/slow periods
- allow custom timeframes for DMA checks and CLI options
- update filtering logic to use parameterised EMAs
- expand run frequency options and schedule helper
- adjust unit tests for new API

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675347a69483208c51975538ca08a9