### PR TITLE
Add intraday offset and verbose scheduling

### DIFF
--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -10,6 +10,7 @@ from .market_predictor import (
     send_telegram_message,
 )
 from .utils import printf
+from run_scan import schedule_scan_with_prediction
 
 __all__ = [
     "fetch_fno_list",
@@ -19,5 +20,6 @@ __all__ = [
     "predict_index_movement",
     "compare_with_indices",
     "send_telegram_message",
+    "schedule_scan_with_prediction",
     "printf",
 ]

--- a/run_scan.py
+++ b/run_scan.py
@@ -119,6 +119,24 @@ def schedule_scan(freq_minutes: int = 15, **kwargs) -> None:
         time.sleep(freq_minutes * 60)
 
 
+def schedule_scan_with_prediction(freq_minutes: int = 15, **kwargs) -> None:
+    """Run :func:`run` periodically and print shortlisted stocks and prediction.
+
+    Parameters
+    ----------
+    freq_minutes : int, optional
+        Number of minutes between runs.
+    """
+    import time
+
+    while True:
+        results = run(**kwargs)
+        prob = predict_index_movement(len(results))
+        print(f"Stocks ({len(results)}): {', '.join(results)}")
+        print(f"Predicted market up move probability: {prob:.1%}")
+        time.sleep(freq_minutes * 60)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="NSE F&O bullish setup scanner")
     parser.add_argument(

--- a/tests/test_dma_filter.py
+++ b/tests/test_dma_filter.py
@@ -35,3 +35,17 @@ def test_filter_by_dma_handles_multiindex(monkeypatch):
     monkeypatch.setattr(yf, "download", fake_download)
     out = filter_by_dma(["TEST"], offset=1)
     assert out == ["TEST"]
+
+
+def test_filter_by_dma_lower_offset(monkeypatch):
+    daily = pd.DataFrame({"Close": range(1, 61), "Open": range(1, 61)})
+    intraday = pd.DataFrame({"Close": range(1, 61)})
+
+    def fake_download(symbol, *args, **kwargs):
+        if kwargs.get("interval") == "1d":
+            return daily
+        return intraday
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    out = filter_by_dma(["TEST"], offset=1, lower_offset=1)
+    assert out == ["TEST"]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,6 +3,7 @@ from nse_fno_scanner import (
     filter_by_dma,
     intraday_scan,
     backtest_strategy,
+    schedule_scan_with_prediction,
     printf,
 )
 
@@ -12,4 +13,5 @@ def test_root_exports_callable():
     assert callable(filter_by_dma)
     assert callable(intraday_scan)
     assert callable(backtest_strategy)
+    assert callable(schedule_scan_with_prediction)
     assert callable(printf)


### PR DESCRIPTION
## Summary
- support ignoring most recent intraday bars in `filter_by_dma`
- add `schedule_scan_with_prediction` helper and export it
- expose new helper in package
- test new intraday offset option
- test new export

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686759e398d48320a785cf8dd06acc90