### PR TITLE
Enable multi-timeframe scan options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ Run the scanner with notifications enabled:
 python run_scan.py --notify
 ```
 
+To continuously run the scan every 15 minutes and print predictions, use
+
+```bash
+python run_scan.py --schedule-pred --freq 15
+```
+
 Additional options are available:
 
 ```
@@ -57,6 +63,10 @@ Additional options are available:
 --fno-url  Custom CSV URL for the F&O stock list
 --debug    Enable debug logging output
 --bt-period  Period of data for the backtester (default "6mo")
+--bt-interval  Data interval for the backtester
+--offset       Higher timeframe offset when checking DMAs
+--lower-offset Lower timeframe offset for intraday pattern
+--schedule-pred  Run scan periodically and print predictions
 ```
 
 If a file named `fno_list.csv` is present in the project directory it will

--- a/nse_fno_scanner/backtester.py
+++ b/nse_fno_scanner/backtester.py
@@ -44,7 +44,11 @@ class EMABacktestStrategy(bt.Strategy):
 
 
 def backtest_strategy(
-    symbol: str, period: str = "6mo", fast: int = 20, slow: int = 50
+    symbol: str,
+    period: str = "6mo",
+    fast: int = 20,
+    slow: int = 50,
+    interval: str = "1d",
 ) -> Tuple[int, float, float]:
     """Backtest the intraday strategy on daily data for a symbol.
 
@@ -54,6 +58,8 @@ def backtest_strategy(
         Equity ticker symbol without NSE suffix.
     period : str, optional
         Period to download historical data for (default "6mo").
+    interval : str, optional
+        Data interval for the download (default ``"1d"``).
     fast : int, optional
         Fast EMA period for the strategy.
     slow : int, optional
@@ -69,7 +75,7 @@ def backtest_strategy(
         df = yf.download(
             f"{symbol}.NS",
             period=period,
-            interval="1d",
+            interval=interval,
             progress=False,
             multi_level_index=False,
         )


### PR DESCRIPTION
## Summary
- add backtest interval option
- expose DMA and intraday offsets in run options
- support scheduled prediction mode from CLI
- document new options in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6867fd44cfa083209f2b34db32ea5cfa