### PR TITLE
Improve backtester and integrate logging

### DIFF
--- a/run_scan.py
+++ b/run_scan.py
@@ -99,6 +99,7 @@ def run(
 
     if backtest:
         print("\nBacktest results:")
+        log_lines = []
         for sym in results:
             trades, win_rate, avg_ret = backtest_strategy(
                 sym,
@@ -108,8 +109,12 @@ def run(
                 interval=bt_interval,
             )
             print(
-                f"{sym}: trades={trades}, win_rate={win_rate:.1f}%, avg_return={avg_ret:.2f}%"
+                f"{sym}: trades={trades}, avg_return={avg_ret * 100:.2f}%, win_rate={win_rate * 100:.1f}%"
             )
+            log_lines.append(
+                f"{sym},{trades},{avg_ret * 100:.2f},{win_rate * 100:.1f}"
+            )
+        Path("backtest_results.txt").write_text("\n".join(log_lines))
 
     if notify:
         prob = predict_index_movement(len(results))

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -17,4 +17,4 @@ def test_backtest_strategy(monkeypatch):
     monkeypatch.setattr(yf, "download", fake_download)
     trades, win_rate, avg_ret = backtest_strategy("TEST")
     assert trades >= 0
-    assert 0.0 <= win_rate <= 100.0
+    assert 0.0 <= win_rate <= 1.0


### PR DESCRIPTION
## Summary
- fix backtester returns and win rate logic
- log trades for debugging
- report backtest results in run_scan and save to **backtest_results.txt**
- update tests for new win rate format

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868042a74c08320b874b1ebe53d0eba