### PR TITLE
Improve multi-timeframe scanner and backtester

### DIFF
--- a/nse_fno_scanner/intraday_scanner.py
+++ b/nse_fno_scanner/intraday_scanner.py
@@ -35,22 +35,21 @@ def pattern_confirmed(df: pd.DataFrame) -> bool:
         return False
     c = df["Close"]
     return (
-        c.iloc[-2] > c.iloc[-3]
-        and c.iloc[-1] > c.iloc[-2]
-        and c.iloc[-3] > c.iloc[-4]
+        c.iloc[-2] > c.iloc[-3] and c.iloc[-1] > c.iloc[-2] and c.iloc[-3] > c.iloc[-4]
     )
 
 
-def intraday_scan(symbols: Iterable[str]) -> List[str]:
+def intraday_scan(symbols: Iterable[str], interval: str = "15m") -> List[str]:
     shortlisted = []
     for symbol in tqdm(list(symbols), desc="Intraday scan"):
         try:
             logger.debug("Downloading intraday data for %s", symbol)
             df = yf.download(
                 f"{symbol}.NS",
-                period="3d",
-                interval="15m",
+                period="2d",
+                interval=interval,
                 progress=False,
+                auto_adjust=False,
                 multi_level_index=False,
             )
             if isinstance(df.columns, pd.MultiIndex):
@@ -58,7 +57,7 @@ def intraday_scan(symbols: Iterable[str]) -> List[str]:
         except Exception as exc:
             logger.debug("Failed to download %s: %s", symbol, exc)
             continue
-        if df.empty or len(df) < 50:
+        if df.empty or len(df) < 5:
             continue
         df = compute_emas(df)
         last_row = df.iloc[-1]

--- a/nse_fno_scanner/utils.py
+++ b/nse_fno_scanner/utils.py
@@ -6,4 +6,3 @@ from __future__ import annotations
 def printf(fmt: str, *args, flush: bool = True) -> None:
     """Print formatted message to stdout, similar to C printf."""
     print(fmt % args if args else fmt, flush=flush)
-

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -9,7 +9,7 @@ from nse_fno_scanner import backtest_strategy
 
 
 def test_backtest_strategy(monkeypatch):
-    data = pd.DataFrame({"Close": list(range(1, 120))})
+    data = pd.DataFrame({"Open": list(range(1, 120)), "Close": list(range(1, 120))})
 
     def fake_download(*args, **kwargs):
         return data

--- a/tests/test_dma_filter.py
+++ b/tests/test_dma_filter.py
@@ -11,11 +11,11 @@ from nse_fno_scanner.dma_filter import compute_dmas, filter_by_dma
 def test_compute_dmas():
     data = pd.DataFrame({"Close": range(1, 61)})
     df = compute_dmas(data)
-    assert "EMA20" in df.columns and "EMA50" in df.columns
-    assert not df["EMA20"].isna().all()
-    assert not df["EMA50"].isna().all()
+    assert "DMA20" in df.columns and "DMA50" in df.columns
+    assert not df["DMA20"].isna().all()
+    assert not df["DMA50"].isna().all()
     last = df.iloc[-1]
-    assert last["EMA20"] > last["EMA50"]
+    assert last["DMA20"] > last["DMA50"]
 
 
 def test_filter_by_dma_handles_multiindex(monkeypatch):
@@ -23,29 +23,20 @@ def test_filter_by_dma_handles_multiindex(monkeypatch):
     close = pd.Series(range(1, 61), index=dates)
     daily = pd.DataFrame({("Close", "TEST"): close, ("Open", "TEST"): close})
 
-    idates = pd.date_range("2020-03-01", periods=60, freq="15T")
-    iclose = pd.Series(range(1, 61), index=idates)
-    intraday = pd.DataFrame({("Close", "TEST"): iclose})
-
     def fake_download(symbol, *args, **kwargs):
-        if kwargs.get("interval") == "1d":
-            return daily
-        return intraday
+        return daily
 
     monkeypatch.setattr(yf, "download", fake_download)
     out = filter_by_dma(["TEST"], offset=1)
     assert out == ["TEST"]
 
 
-def test_filter_by_dma_lower_offset(monkeypatch):
+def test_filter_by_dma_offset(monkeypatch):
     daily = pd.DataFrame({"Close": range(1, 61), "Open": range(1, 61)})
-    intraday = pd.DataFrame({"Close": range(1, 61)})
 
     def fake_download(symbol, *args, **kwargs):
-        if kwargs.get("interval") == "1d":
-            return daily
-        return intraday
+        return daily
 
     monkeypatch.setattr(yf, "download", fake_download)
-    out = filter_by_dma(["TEST"], offset=1, lower_offset=1)
+    out = filter_by_dma(["TEST"], offset=1)
     assert out == ["TEST"]

--- a/tests/test_run_scan.py
+++ b/tests/test_run_scan.py
@@ -9,15 +9,21 @@ import run_scan
 def test_run_with_notify(monkeypatch, tmp_path):
     monkeypatch.setattr(run_scan, "fetch_fno_list", lambda: ["A"])
     monkeypatch.setattr(run_scan, "filter_by_dma", lambda syms, **kw: syms)
-    monkeypatch.setattr(run_scan, "intraday_scan", lambda syms: ["A"])
+    monkeypatch.setattr(run_scan, "intraday_scan", lambda syms, **kw: ["A"])
     monkeypatch.setattr(run_scan, "backtest_strategy", lambda sym: (0, 0.0, 0.0))
 
     sent = {}
+
     def fake_send(msg):
         sent["msg"] = msg
+
     monkeypatch.setattr(run_scan, "send_telegram_message", fake_send)
     monkeypatch.setattr(run_scan, "predict_index_movement", lambda c: 0.5)
-    monkeypatch.setattr(run_scan, "compare_with_indices", lambda syms: {"stocks":0.01,"nifty":0.02,"banknifty":0.03})
+    monkeypatch.setattr(
+        run_scan,
+        "compare_with_indices",
+        lambda syms: {"stocks": 0.01, "nifty": 0.02, "banknifty": 0.03},
+    )
 
     out = tmp_path / "out.txt"
     run_scan.run(out, backtest=False, notify=True)


### PR DESCRIPTION
## Summary
- simplify DMA filter to use simple moving averages
- tighten intraday scanner and expose interval option
- rewrite backtester for 15m intraday candles
- streamline CLI to use new interval option
- adjust tests for new behaviour and formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686806e2bc948320b15f6e2adfed649b