### PR TITLE
Add trading simulation utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ from nse_fno_scanner import printf
 printf("Scanning %s symbols", len(symbols))
 ```
 
+### Market simulation
+
+The package includes helper functions to simulate a simple intraday strategy on
+multiple stocks. Use ``simulate_market`` to generate trade logs and PnL in a
+DataFrame and ``plot_pnl`` to visualise the cumulative returns.
+
+```python
+from nse_fno_scanner import simulate_market, plot_pnl
+
+shortlisted, df = simulate_market(["RELIANCE", "TCS"], days=10)
+plot_pnl(df)
+```
+
 ## Google Colab
 
 You can try the scanner in the browser using

--- a/docs/detailed_tutorial.md
+++ b/docs/detailed_tutorial.md
@@ -120,4 +120,18 @@ These options allow experimentation with different strategy parameters.
    ```
 
 This sequence demonstrates how the tool can fit into a daily trading routine –
-continuous monitoring followed by deeper analysis on demand.
+ continuous monitoring followed by deeper analysis on demand.
+
+## 9. Simulating trades
+
+For research purposes you can simulate the intraday strategy over a list of
+symbols. The ``simulate_market`` function returns both the shortlisted stocks
+and a DataFrame containing trade logs and cumulative PnL. ``plot_pnl`` provides
+a quick visualisation.
+
+```python
+from nse_fno_scanner import simulate_market, plot_pnl
+
+shortlist, df = simulate_market(["RELIANCE", "TCS"], days=10)
+plot_pnl(df)
+```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -30,3 +30,15 @@ Or pass a URL or local file via `--fno-url` if you maintain your own list.
 
 For interactive exploration open `NiftyStocks_Colab.ipynb` on Google Colab and
 execute the notebook cells sequentially.
+
+### Simulating trades
+
+Within a notebook you can run a quick simulation to see how the intraday
+strategy performs:
+
+```python
+from nse_fno_scanner import simulate_market, plot_pnl
+
+shortlist, df = simulate_market(["RELIANCE", "TCS"], days=10)
+plot_pnl(df)
+```

--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -4,6 +4,7 @@ from .fetch_fno_list import fetch_fno_list
 from .dma_filter import filter_by_dma
 from .intraday_scanner import intraday_scan
 from .backtester import backtest_strategy
+from .simulator import simulate_market, plot_pnl
 from .market_predictor import (
     predict_index_movement,
     compare_with_indices,
@@ -17,6 +18,8 @@ __all__ = [
     "filter_by_dma",
     "intraday_scan",
     "backtest_strategy",
+    "simulate_market",
+    "plot_pnl",
     "predict_index_movement",
     "compare_with_indices",
     "send_telegram_message",

--- a/nse_fno_scanner/backtester.py
+++ b/nse_fno_scanner/backtester.py
@@ -47,7 +47,8 @@ def backtest_strategy(
     start_hour: int | None = None,
     fast: int = 20,
     slow: int = 50,
-) -> Tuple[int, float, float]:
+    return_trades: bool = False,
+) -> Tuple[int, float, float] | Tuple[int, float, float, List[Trade]]:
     """Backtest the intraday EMA pattern for ``symbol``.
 
     Each day where the pattern occurs triggers a trade: buy on the first candle
@@ -88,4 +89,6 @@ def backtest_strategy(
     returns = [t.pct_return for t in trades]
     win_rate = sum(r > 0 for r in returns) / len(returns)
     avg_return = sum(returns) / len(returns)
+    if return_trades:
+        return len(trades), win_rate, avg_return, trades
     return len(trades), win_rate, avg_return

--- a/nse_fno_scanner/simulator.py
+++ b/nse_fno_scanner/simulator.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Market simulation utilities."""
+
+from pathlib import Path
+from typing import Iterable, Tuple, List
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from .backtester import backtest_strategy, Trade
+
+
+def simulate_market(
+    symbols: Iterable[str],
+    *,
+    days: int = 5,
+    interval: str = "15m",
+    fast: int = 20,
+    slow: int = 50,
+    save_path: str | None = None,
+) -> Tuple[List[str], pd.DataFrame]:
+    """Simulate trading on ``symbols`` using the intraday strategy.
+
+    Parameters
+    ----------
+    symbols : Iterable[str]
+        Symbols to backtest.
+    save_path : str, optional
+        If given, shortlisted symbols are written to this path one per line.
+
+    Returns
+    -------
+    Tuple[List[str], pd.DataFrame]
+        List of shortlisted symbols and DataFrame with trade logs and PnL.
+    """
+
+    shortlisted: List[str] = []
+    logs: List[dict] = []
+    for sym in symbols:
+        trades, win_rate, avg_ret, trade_log = backtest_strategy(
+            sym,
+            days=days,
+            interval=interval,
+            fast=fast,
+            slow=slow,
+            return_trades=True,
+        )
+        if trades > 0:
+            shortlisted.append(sym)
+            for t in trade_log:
+                logs.append(
+                    {
+                        "symbol": sym,
+                        "date": t.date,
+                        "entry": t.entry,
+                        "exit": t.exit,
+                        "pct_return": t.pct_return,
+                    }
+                )
+
+    if save_path is not None:
+        Path(save_path).write_text("\n".join(shortlisted))
+
+    df = pd.DataFrame(logs)
+    if not df.empty:
+        df["pnl"] = df["pct_return"]
+        df["cum_pnl"] = df["pnl"].cumsum()
+    return shortlisted, df
+
+
+def plot_pnl(df: pd.DataFrame, ax=None):
+    """Plot cumulative PnL from a DataFrame returned by :func:`simulate_market`."""
+    if df.empty:
+        return None
+    if ax is None:
+        fig, ax = plt.subplots()
+    ax.plot(df["date"], df["cum_pnl"], marker="o")
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Cumulative PnL")
+    ax.set_title("Strategy PnL")
+    return ax

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-telegram-bot
 gdown
 
 backtrader
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "numpy",
         "tqdm",
         "gdown",
+        "matplotlib",
     ],
     entry_points={
         "console_scripts": ["nse-fno-scan=run_scan:main"],

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,6 +3,8 @@ from nse_fno_scanner import (
     filter_by_dma,
     intraday_scan,
     backtest_strategy,
+    simulate_market,
+    plot_pnl,
     schedule_scan_with_prediction,
     printf,
 )
@@ -13,5 +15,7 @@ def test_root_exports_callable():
     assert callable(filter_by_dma)
     assert callable(intraday_scan)
     assert callable(backtest_strategy)
+    assert callable(simulate_market)
+    assert callable(plot_pnl)
     assert callable(schedule_scan_with_prediction)
     assert callable(printf)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pandas as pd
+import yfinance as yf
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nse_fno_scanner.simulator import simulate_market, plot_pnl
+
+
+def test_simulate_market(monkeypatch):
+    data = pd.DataFrame({"Open": range(1, 120), "Close": range(1, 120)})
+
+    def fake_download(*args, **kwargs):
+        return data
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    shortlist, df = simulate_market(["AAA", "BBB"], days=2)
+    assert shortlist == ["AAA", "BBB"]
+    assert not df.empty
+    assert "cum_pnl" in df.columns
+
+
+def test_plot_pnl(monkeypatch):
+    df = pd.DataFrame({"date": pd.date_range("2020-01-01", periods=3), "cum_pnl": [0, 1, 2]})
+    ax = plot_pnl(df)
+    assert ax is not None


### PR DESCRIPTION
## Summary
- add `simulate_market` and `plot_pnl` utilities
- support returning trade logs from `backtest_strategy`
- expose new helpers from package root
- document market simulation usage in README and docs
- add matplotlib dependency
- tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a13a1c208320b12be8989722b075