### PR TITLE
Add OHLC fetcher and backtesting docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ line, inside a Jupyter notebook or in Google Colab.
   tickers when you want to focus on a subset of stocks.
 * **Research and backtesting** – import the package in your own Python scripts
   to experiment with the moving‑average filters or historical data used by the
-  scanner.
+  scanner. Example code is available in
+  [docs/backtesting_example.md](docs/backtesting_example.md).
 
 ## Usage
 

--- a/docs/backtesting_example.md
+++ b/docs/backtesting_example.md
@@ -1,0 +1,57 @@
+# Backtesting Examples
+
+This page demonstrates how to download OHLC data and run quick backtests using
+both [Backtrader](https://www.backtrader.com/) and the utilities bundled with
+this project.
+
+## Fetching OHLC data
+
+Use :func:`nse_fno_scanner.fetch_ohlc` to grab data from Yahoo Finance:
+
+```python
+from nse_fno_scanner import fetch_ohlc
+
+# Daily bars
+df_daily = fetch_ohlc("RELIANCE", days=60, interval="1d")
+
+# 15 minute bars
+df_15m = fetch_ohlc("RELIANCE", days=5, interval="15m")
+```
+
+## Backtesting with Backtrader
+
+The snippet below implements a simple moving average crossover strategy with
+Backtrader.
+
+```python
+import backtrader as bt
+from nse_fno_scanner import fetch_ohlc
+
+class SmaCross(bt.SignalStrategy):
+    def __init__(self):
+        sma1 = bt.ind.SMA(period=20)
+        sma2 = bt.ind.SMA(period=50)
+        crossover = bt.ind.CrossOver(sma1, sma2)
+        self.signal_add(bt.SIGNAL_LONG, crossover)
+
+# Load daily data for six months
+df = fetch_ohlc("RELIANCE", days=180, interval="1d")
+
+data = bt.feeds.PandasData(dataname=df)
+cerebro = bt.Cerebro()
+cerebro.add_strategy(SmaCross)
+cerebro.add_data(data)
+cerebro.run()
+cerebro.plot()
+```
+
+## Using the built-in backtester
+
+For a lightweight alternative you can use :func:`nse_fno_scanner.backtest_strategy`:
+
+```python
+from nse_fno_scanner import backtest_strategy
+
+trades, win_rate, avg_ret = backtest_strategy("RELIANCE", days=10, interval="15m")
+print(trades, win_rate, avg_ret)
+```

--- a/nse_fno_scanner/__init__.py
+++ b/nse_fno_scanner/__init__.py
@@ -5,6 +5,7 @@ from .dma_filter import filter_by_dma
 from .intraday_scanner import intraday_scan
 from .backtester import backtest_strategy
 from .simulator import simulate_market, plot_pnl
+from .ohlc import fetch_ohlc
 from .market_predictor import (
     predict_index_movement,
     compare_with_indices,
@@ -20,6 +21,7 @@ __all__ = [
     "backtest_strategy",
     "simulate_market",
     "plot_pnl",
+    "fetch_ohlc",
     "predict_index_movement",
     "compare_with_indices",
     "send_telegram_message",

--- a/nse_fno_scanner/ohlc.py
+++ b/nse_fno_scanner/ohlc.py
@@ -1,0 +1,40 @@
+"""Download OHLC data for NSE stocks."""
+
+from __future__ import annotations
+
+import pandas as pd
+import yfinance as yf
+
+
+def fetch_ohlc(symbol: str, *, days: int = 30, interval: str = "1d") -> pd.DataFrame:
+    """Fetch OHLC data from Yahoo Finance for ``symbol``.
+
+    Parameters
+    ----------
+    symbol : str
+        NSE ticker without the ``.NS`` suffix.
+    days : int, optional
+        Number of days of history to request. Defaults to ``30``.
+    interval : str, optional
+        Data interval such as ``"1d"`` for daily or ``"15m"`` for intraday.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed by datetime containing the OHLC data.
+    """
+
+    df = yf.download(
+        f"{symbol}.NS",
+        period=f"{days}d",
+        interval=interval,
+        progress=False,
+        auto_adjust=False,
+        multi_level_index=False,
+    )
+    if isinstance(df.columns, pd.MultiIndex):
+        df.columns = df.columns.get_level_values(0)
+    return df
+
+
+__all__ = ["fetch_ohlc"]

--- a/tests/test_ohlc.py
+++ b/tests/test_ohlc.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pandas as pd
+import yfinance as yf
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from nse_fno_scanner.ohlc import fetch_ohlc
+
+
+def test_fetch_ohlc(monkeypatch):
+    data = pd.DataFrame({"Open": [1, 2], "Close": [1, 2]})
+
+    def fake_download(ticker, *args, **kwargs):
+        assert ticker == "TEST.NS"
+        assert kwargs["period"] == "30d"
+        assert kwargs["interval"] == "15m"
+        return data
+
+    monkeypatch.setattr(yf, "download", fake_download)
+    df = fetch_ohlc("TEST", days=30, interval="15m")
+    assert df.equals(data)


### PR DESCRIPTION
## Summary
- implement `fetch_ohlc` helper for daily and intraday data
- export `fetch_ohlc` in the package
- document example usage with Backtrader and built-in backtester
- mention the new guide in the README
- test `fetch_ohlc`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a98a72e188320a644ea91cc9f70b8