### PR TITLE
Add combined scan/backtest modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Additional options are available:
 --debug    Enable debug logging output
 --bt-period  Period of data for the backtester (default "6mo")
 --bt-interval  Data interval for the backtester
+--mode         Run only daily, intraday or both scans (default "both")
+--bt-mode      Backtest mode (default same as --mode)
 --offset       Higher timeframe offset when checking DMAs
 --lower-offset Lower timeframe offset for intraday pattern
 --schedule-pred  Run scan periodically and print predictions

--- a/docs/backtesting_example.md
+++ b/docs/backtesting_example.md
@@ -52,6 +52,8 @@ For a lightweight alternative you can use :func:`nse_fno_scanner.backtest_strate
 ```python
 from nse_fno_scanner import backtest_strategy
 
-trades, win_rate, avg_ret = backtest_strategy("RELIANCE", days=10, interval="15m")
+trades, win_rate, avg_ret = backtest_strategy(
+    "RELIANCE", period="30d", interval="15m", mode="intraday"
+)
 print(trades, win_rate, avg_ret)
 ```

--- a/docs/detailed_tutorial.md
+++ b/docs/detailed_tutorial.md
@@ -29,8 +29,8 @@ Typical use cases:
 
 ## 3. Backtesting shortlisted stocks
 
-Pass `--backtest` to run a simple moving-average backtest on all shortlisted
-symbols. The backtester uses daily data from Yahoo Finance.
+Pass `--backtest` to run a moving-average backtest on all shortlisted
+symbols. Use `--bt-mode` to choose `daily`, `intraday` or `both`.
 
 ```bash
 python run_scan.py --symbols=RELIANCE,INFY --backtest

--- a/nse_fno_scanner/simulator.py
+++ b/nse_fno_scanner/simulator.py
@@ -14,7 +14,7 @@ from .backtester import backtest_strategy, Trade
 def simulate_market(
     symbols: Iterable[str],
     *,
-    days: int = 5,
+    period: str = "6mo",
     interval: str = "15m",
     fast: int = 20,
     slow: int = 50,
@@ -40,8 +40,9 @@ def simulate_market(
     for sym in symbols:
         trades, win_rate, avg_ret, trade_log = backtest_strategy(
             sym,
-            days=days,
+            period=period,
             interval=interval,
+            mode="intraday",
             fast=fast,
             slow=slow,
             return_trades=True,

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -15,6 +15,7 @@ def test_backtest_strategy(monkeypatch):
         return data
 
     monkeypatch.setattr(yf, "download", fake_download)
-    trades, win_rate, avg_ret = backtest_strategy("TEST")
-    assert trades >= 0
-    assert 0.0 <= win_rate <= 1.0
+    for mode in ["intraday", "daily", "both"]:
+        trades, win_rate, avg_ret = backtest_strategy("TEST", mode=mode)
+        assert trades >= 0
+        assert 0.0 <= win_rate <= 1.0

--- a/tests/test_run_scan.py
+++ b/tests/test_run_scan.py
@@ -10,7 +10,7 @@ def test_run_with_notify(monkeypatch, tmp_path):
     monkeypatch.setattr(run_scan, "fetch_fno_list", lambda: ["A"])
     monkeypatch.setattr(run_scan, "filter_by_dma", lambda syms, **kw: syms)
     monkeypatch.setattr(run_scan, "intraday_scan", lambda syms, **kw: ["A"])
-    monkeypatch.setattr(run_scan, "backtest_strategy", lambda sym: (0, 0.0, 0.0))
+    monkeypatch.setattr(run_scan, "backtest_strategy", lambda sym, **kw: (0, 0.0, 0.0))
 
     sent = {}
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -15,7 +15,7 @@ def test_simulate_market(monkeypatch):
         return data
 
     monkeypatch.setattr(yf, "download", fake_download)
-    shortlist, df = simulate_market(["AAA", "BBB"], days=2)
+    shortlist, df = simulate_market(["AAA", "BBB"], period="2d")
     assert shortlist == ["AAA", "BBB"]
     assert not df.empty
     assert "cum_pnl" in df.columns


### PR DESCRIPTION
## Summary
- add `mode` and `bt-mode` options to choose daily/intraday/both scans
- expand backtester to support daily strategy and combined modes
- update simulator, README and docs
- adjust tests for new API

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aa6c7e974832091fc2e11ccdb1503